### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,9 @@ submission {
 
 dependencies {
     implementation("org.junit-pioneer:junit-pioneer:1.7.1")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
-    implementation("org.tudalgo:algoutils-tutor:0.1.0-SNAPSHOT")
-    implementation("org.tudalgo:algoutils-student:0.1.0-SNAPSHOT")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.0")
+    implementation("org.tudalgo:algoutils-tutor:0.6.3")
+    implementation("org.tudalgo:algoutils-student:0.6.3")
 }
 
 jagr {


### PR DESCRIPTION
The GraderPublicRun breaks when using the current versions