### PR TITLE
Improve error message of test 7

### DIFF
--- a/src/graderPublic/java/h11/h3/ParsedLSystemTest.java
+++ b/src/graderPublic/java/h11/h3/ParsedLSystemTest.java
@@ -50,12 +50,15 @@ public class ParsedLSystemTest {
     @ParameterizedTest
     @JsonClasspathSource("h11/h3/parsed-lsystem-test.json")
     @Tag("H3")
-    public void testThat_projectionsOfUnknownDoesNotProject(ParsedLSystemTestCase testCase) throws NoSuchMethodException {
+    public void testThat_projectionsOfUnknownDoesNotProject(ParsedLSystemTestCase testCase) {
         var lSystem = new ParsedLSystem(testCase.projections());
-
-        for (char c = '0'; c <= '9'; c++) {
-            Assertions2.assertEquals(List.of(c), lSystem.project(c).toList(), getProjectContext(), result ->
-                "The unknown source was not ignored correctly");
+        try{
+            for (char c = '0'; c <= '9'; c++) {
+                Assertions2.assertEquals(List.of(c), lSystem.project(c).toList(), getProjectContext(), result ->
+                    "The unknown source was not ignored correctly");
+            }
+        } catch (Exception exc) {
+            throw new AssertionError(exc.getClass());
         }
     }
 


### PR DESCRIPTION
I don't think this is an ideal solution.
For some reason, the exception message is always null should an exception be thrown.
I was unable to replicate this when running the test method on it's own though so it might be a bug.
This would at least provide the type of exception, in my testing, I used an ArrayIndexOutOfBoundsException.